### PR TITLE
#29 Set project encoding to UTF-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,8 @@
     <url>https://github.com/tdiesler/wsdl2rest</url>
     
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        
         <version.apache.camel>2.18.0</version.apache.camel>
         <version.apache.cxf>3.1.7</version.apache.cxf>
         <version.apache.velocity>1.7</version.apache.velocity>


### PR DESCRIPTION
it avoids to have platform-dependent build

Signed-off-by: Aurélien Pupier <apupier@redhat.com>