### PR TITLE
Upgrade args4j from 2.0.31 to 2.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <version.apache.camel>2.18.0</version.apache.camel>
         <version.apache.cxf>3.1.7</version.apache.cxf>
         <version.apache.velocity>1.7</version.apache.velocity>
-        <version.args4j>2.0.31</version.args4j>
+        <version.args4j>2.33</version.args4j>
         <version.javaparser>2.5.1</version.javaparser>
         <version.javax.ws.rs.api>2.0.1</version.javax.ws.rs.api>
         <version.junit>4.11</version.junit>


### PR DESCRIPTION
Signed-off-by: Aurélien Pupier <apupier@redhat.com>