### PR TITLE
Ensure Camel rest generated with rest endpoints even with underscored

### DIFF
--- a/impl/src/main/java/org/jboss/fuse/wsdl2rest/impl/ResourceMapperImpl.java
+++ b/impl/src/main/java/org/jboss/fuse/wsdl2rest/impl/ResourceMapperImpl.java
@@ -29,7 +29,7 @@ public class ResourceMapperImpl implements ResourceMapper {
     private Pattern httpPostWordsPattern = Pattern.compile(httpPostWords);
     private Pattern httpDeleteWordsPattern = Pattern.compile(httpDelWords);
     private Pattern httpPutWordsPattern = Pattern.compile(httpPutWords);
-    private Pattern resourcePattern = Pattern.compile("[a-z]+|([A-Z][a-z]+)*");
+    private Pattern resourcePattern = Pattern.compile("[A-Za-z_]+|([A-Z_][a-z_]+)*");
 
     public List<String> getResources() {
         return Collections.unmodifiableList(resources);

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <version.javax.ws.rs.api>2.1</version.javax.ws.rs.api>
         <version.junit>4.12</version.junit>
         <version.assertj>3.11.1</version.assertj>
+        <version.xmlunit>2.6.2</version.xmlunit>
         <version.wsdl4j>1.6.3</version.wsdl4j>
         
         <!-- Plugin versions -->
@@ -74,6 +75,11 @@
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${version.assertj}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.xmlunit</groupId>
+                <artifactId>xmlunit-core</artifactId>
+                <version>${version.xmlunit}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>

--- a/tests/spring/pom.xml
+++ b/tests/spring/pom.xml
@@ -66,6 +66,12 @@
         <dependency>
         	<groupId>org.assertj</groupId>
         	<artifactId>assertj-core</artifactId>
+        	<scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     

--- a/tests/spring/src/test/java/org/jboss/fuse/wsdl2rest/test/WithUnderscoreTest.java
+++ b/tests/spring/src/test/java/org/jboss/fuse/wsdl2rest/test/WithUnderscoreTest.java
@@ -21,12 +21,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
+
+import javax.xml.transform.Source;
 
 import org.jboss.fuse.wsdl2rest.EndpointInfo;
 import org.jboss.fuse.wsdl2rest.MethodInfo;
 import org.jboss.fuse.wsdl2rest.impl.Wsdl2Rest;
 import org.junit.Test;
+import org.w3c.dom.Node;
+import org.xmlunit.builder.Input;
+import org.xmlunit.xpath.JAXPXPathEngine;
 
 public class WithUnderscoreTest {
 	
@@ -44,9 +50,15 @@ public class WithUnderscoreTest {
 	        assertThat(clazzDef.getPackageName()).isEqualTo("1.com/Enterprise/HCM/services/A_NAME_WITH_UNDERSCORE_SRV.oracle.xmlns");
 	        assertThat(clazzDef.getClassName()).isEqualTo("A_NAME_WITH_UNDERSCORE_SRV_PortType");
 	        MethodInfo method = clazzDef.getMethod("A_SECOND_NAME_WITH_UNDERSCORE_EMAIL_OPR_SRV");
-	        assertThat(method.getPath()).isEqualTo("/{arg0}");
+	        assertThat(method.getPath()).isEqualTo("a_second_name_with_underscore_email_opr_srv/{arg0}");
 	        
 	        File cctxFile = outpath.resolve(Paths.get("camel", "wsdl2rest-camel-context.xml")).toFile();
 	        assertThat(cctxFile).exists();
+	        
+	        Source camelSourceFile = Input.fromFile(cctxFile).build();
+	        JAXPXPathEngine jaxpxPathEngine = new JAXPXPathEngine();
+	        jaxpxPathEngine.setNamespaceContext(Collections.singletonMap("camel", "http://camel.apache.org/schema/spring"));
+			Iterable<Node> restPostNodes = jaxpxPathEngine.selectNodes("//camel:camelContext/camel:rest/camel:get", camelSourceFile);
+	        assertThat(restPostNodes).hasSize(1);
 	    }
 }

--- a/tests/spring/src/test/java/org/jboss/fuse/wsdl2rest/test/calculator/CalculatorDocLitTest.java
+++ b/tests/spring/src/test/java/org/jboss/fuse/wsdl2rest/test/calculator/CalculatorDocLitTest.java
@@ -16,15 +16,23 @@
  */
 package org.jboss.fuse.wsdl2rest.test.calculator;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
+
+import javax.xml.transform.Source;
 
 import org.jboss.fuse.wsdl2rest.EndpointInfo;
 import org.jboss.fuse.wsdl2rest.impl.Wsdl2Rest;
 import org.junit.Assert;
 import org.junit.Test;
+import org.w3c.dom.Node;
+import org.xmlunit.builder.Input;
+import org.xmlunit.xpath.JAXPXPathEngine;
 
 
 public class CalculatorDocLitTest {
@@ -33,7 +41,7 @@ public class CalculatorDocLitTest {
     public void testJavaClient() throws Exception {
         
         File wsdlFile = new File("src/test/resources/calculator/calculator.wsdl");
-        Assert.assertTrue(wsdlFile.exists());
+        assertThat(wsdlFile).exists();
         
         Path outpath = Paths.get("target/wsdl2rest/calculator");
         Wsdl2Rest wsdl2Rest = new Wsdl2Rest(wsdlFile.toURI().toURL(), outpath);
@@ -45,6 +53,11 @@ public class CalculatorDocLitTest {
         Assert.assertEquals("ICalculator", clazzDef.getClassName());
         
         File cctxFile = outpath.resolve(Paths.get("camel", "wsdl2rest-camel-context.xml")).toFile();
-        Assert.assertTrue(cctxFile.exists());
+        assertThat(cctxFile).exists();
+        Source camelSourceFile = Input.fromFile(cctxFile).build();
+        JAXPXPathEngine jaxpxPathEngine = new JAXPXPathEngine();
+        jaxpxPathEngine.setNamespaceContext(Collections.singletonMap("camel", "http://camel.apache.org/schema/spring"));
+		Iterable<Node> restPostNodes = jaxpxPathEngine.selectNodes("//camel:camelContext/camel:rest/camel:post", camelSourceFile);
+        assertThat(restPostNodes).hasSize(2);
     }
 }


### PR DESCRIPTION
names #66

- improved test to check for it
- support underscores in names

Some tests are failing but creating to ease discussion on this issue.

[ERROR] Errors: 
[ERROR]   CamelRestDocLitTest.testRestClient:132 » NotFound HTTP 404 Not Found
[ERROR]   CamelRestRpcLitTest.testRestClient:132 » NotFound HTTP 404 Not Found
