### PR TITLE
issue #77 - finish cleanup tasks (#79)

### DIFF
--- a/tests/spring/src/test/java/org/jboss/fuse/wsdl2rest/test/calculator/CalculatorDocLitTest.java
+++ b/tests/spring/src/test/java/org/jboss/fuse/wsdl2rest/test/calculator/CalculatorDocLitTest.java
@@ -136,19 +136,16 @@ public class CalculatorDocLitTest {
     }
 
     private boolean searchForValue(String value, Path filePath) throws Exception {
-        Scanner kb = new Scanner(value);
-    	try {
-	        String name = kb.nextLine();
-	
-	        List<String> lines = Files.readAllLines(filePath);
-	        for (String line : lines) {
-	            if (line.contains(name)) {
-	                return true;
-	            }
-	        }
-    	} finally {
-    		kb.close();
-    	}
-    	return false;
-    }    
+        try (Scanner kb = new Scanner(value)) {
+            String name = kb.nextLine();
+
+            List<String> lines = Files.readAllLines(filePath);
+            for (String line : lines) {
+                if (line.contains(name)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
-- fixed indent issues with CalculatorDocLitTest searchForValue
-- fixed searchForValue to use try-with-resource notation

Signed-off-by: Brian Fitzpatrick <bfitzpat@redhat.com>
(cherry picked from commit 08d43de28fb2c6299e70c893058df323b9e861ce)