### PR TITLE
ENTESB-15974 - CVE-2020-13936 velocity - upgrade to velocity 2.3+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
         <version.apache.camel>2.21.0.fuse-730039</version.apache.camel>
         <version.apache.cxf>3.2.7.fuse-730012</version.apache.cxf>
-        <version.apache.velocity>1.7</version.apache.velocity>
+        <version.apache.velocity>2.3</version.apache.velocity>
         <version.args4j>2.33</version.args4j>
         <version.javaparser>2.5.1</version.javaparser>
         <version.javax.ws.rs.api>2.1</version.javax.ws.rs.api>


### PR DESCRIPTION
unable to compile locally due to wrong productized versions so cannot test upgrade of velocity